### PR TITLE
Export htmlbars template.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ TemplateCompiler.prototype.extensions = ['hbs'];
 TemplateCompiler.prototype.targetExtension = 'js';
 TemplateCompiler.prototype.processString = function (string, relativePath) {
   if (this.HTMLBars) {
-    return compileSpec(string)
+    return "export default " + compileSpec(string);
   } else {
     var input = handlbarsTemplateCompiler.precompile(string);
     return "export default Ember.Handlebars.template(" + input + ");\n";

--- a/test/template_compiler_test.js
+++ b/test/template_compiler_test.js
@@ -23,7 +23,7 @@ describe('templateCompilerFilter', function(){
     return builder.build().then(function(results) {
       var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
       var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-      var expected = htmlbarsCompiler(source);
+      var expected = "export default " + htmlbarsCompiler(source);
 
       assert.equal(actual,expected,'They dont match!')
     });


### PR DESCRIPTION
In the ES6 world, if we do not export it the template can never be used.
