### PR TITLE
Always precompile to a string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ TemplateCompiler.prototype.processString = function (string, relativePath) {
   if (this.HTMLBars) {
     return "export default " + compileSpec(string);
   } else {
-    var input = handlbarsTemplateCompiler.precompile(string);
+    var input = handlbarsTemplateCompiler.precompile(string, false);
     return "export default Ember.Handlebars.template(" + input + ")";
   }
 }

--- a/test/template_compiler_test.js
+++ b/test/template_compiler_test.js
@@ -35,7 +35,7 @@ describe('templateCompilerFilter', function(){
     function assertOutput(results) {
       var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
       var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-      var expected = 'export default Ember.Handlebars.template(' + handlbarsTemplateCompiler.precompile(source) + ')';
+      var expected = 'export default Ember.Handlebars.template(' + handlbarsTemplateCompiler.precompile(source, false) + ')';
 
       assert.equal(actual,expected,'They dont match!')
     }


### PR DESCRIPTION
In Handlebars 1.x `false` was the default for `precompile`, but as of 2.0 it is defaulted to `true` (which returns an object literal instead of the string representation of that object).

This is a backwards compatible change.
