### PR TITLE
Add new Ember.HTMLBars.template wrapper.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ TemplateCompiler.prototype.extensions = ['hbs'];
 TemplateCompiler.prototype.targetExtension = 'js';
 TemplateCompiler.prototype.processString = function (string, relativePath) {
   if (this.HTMLBars) {
-    return "var template = " + compileSpec(string) + "\nexport default template;";
+    return "var template = " + compileSpec(string) + "\nexport default Ember.HTMLBars.template(template);";
   } else {
     var input = handlbarsTemplateCompiler.precompile(string, false);
     return "export default Ember.Handlebars.template(" + input + ")";

--- a/test/template_compiler_test.js
+++ b/test/template_compiler_test.js
@@ -25,7 +25,7 @@ describe('templateCompilerFilter', function(){
     return builder.build().then(function(results) {
       var actual = fs.readFileSync(results.directory + '/template.js', { encoding: 'utf8'});
       var source = fs.readFileSync(sourcePath + '/template.hbs', { encoding: 'utf8' });
-      var expected = "var template = " + htmlbarsCompiler(source) + "\nexport default template;";
+      var expected = "var template = " + htmlbarsCompiler(source) + "\nexport default Ember.HTMLBars.template(template);";
 
       assert.equal(actual,expected,'They dont match!')
     });


### PR DESCRIPTION
This was added in Ember for feature parity, and to allow Ember to have the ability to customize the templates just a tad after they have been precompiled.
