### PR TITLE
Checks the ember version for htmlbars rather than the feature flag

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -25,8 +25,9 @@ module.exports = {
   },
 
   htmlbarsOptions: function() {
+    var emberVersion = require(this.project.root + '/' + this.app.bowerDirectory + '/ember/bower.json').version;
     var projectConfig = this.app.project.config(this.app.env);
-    var htmlbarsEnabled = projectConfig.EmberENV.FEATURES['ember-htmlbars'];
+    var htmlbarsEnabled = !/^1\.[0-9]\./.test(emberVersion);
     var htmlbarsComponentGeneration = projectConfig.EmberENV.FEATURES['ember-htmlbars-component-generation'];
 
     var htmlbarsOptions;


### PR DESCRIPTION
This is a short term fix to remove the need to set the feature flag to use HTMLBars in the betas and canary channels
