### PR TITLE
Allow specifying a custom path for ember-template-compiler via Brocfile

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -26,11 +26,22 @@ module.exports = {
   },
 
   emberPath: function() {
-    return path.join(this.project.root, this.app.bowerDirectory, 'ember');
+    var asset = this.app.vendorFiles['ember.js'];
+    var assetPath;
+
+    if (typeof asset === 'object') {
+      assetPath = asset[this.env] || asset.development;
+    } else {
+      assetPath = asset;
+    }
+
+    assetPath = assetPath.replace(path.sep, '/');
+
+    return path.join(this.project.root, path.dirname(assetPath));
   },
 
   htmlbarsOptions: function() {
-    var emberVersion = require(this.emberPath() + '/bower.json').version;
+    var emberVersion = require(this.project.root + '/bower.json').ember;
     var projectConfig = this.app.project.config(this.app.env);
     var htmlbarsEnabled = !/^1\.[0-9]\./.test(emberVersion);
 


### PR DESCRIPTION
We load our ember assets from a custom path, not `app.bowerDirectory`. Hence looking for `ember-template-compiler` inside `bowerDirectory` is causing problems.

IMHO, since ember-cli supports loading such assets via `vendorFiles` I guess `ember-cli-htmlbars` must also support such cases, maybe via 

```js
var app = new EmberApp({
  vendorFiles: {
    'ember.js': {
      development: 'vendor/path/to/ember/ember.debug.js',
      production:  'vendor/path/to/ember/ember.min.js'
    }
  },
  htmlbarsOptions: {
    isHTMLBars: true,
    templateCompiler: require('./vendor/path/to/ember/ember-template-compiler')
  }
});
```

cc @rwjblue  